### PR TITLE
fix: prevent output channel from forcing focus on activation

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -4,7 +4,16 @@
         {
             "type": "npm",
             "script": "watch",
-            "problemMatcher": "$ts-webpack-watch",
+            "problemMatcher": [
+                {
+                    "base": "$tsc-watch",
+                    "background": {
+                        "activeOnStart": true,
+                        "beginsPattern": "^webpack \\d+\\.\\d+\\.\\d+",
+                        "endsPattern": "^(webpack \\d+\\.\\d+\\.\\d+ )?compiled|Failed to compile"
+                    }
+                }
+            ],
             "isBackground": true,
             "presentation": {
                 "reveal": "never",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to the Serilog Syntax Highlighting extension will be documen
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.2] - 2025-10-06
+
+### Fixed
+- Output channel no longer forces focus on activation, preventing workflow interruption
+- Simplified activation logging to single concise line
+- Added proper problem matcher for watch task to eliminate VS Code warnings
+
 ## [0.2.1] - 2025-09-21
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "serilog-syntax-vscode",
   "displayName": "Serilog Syntax",
   "description": "Syntax highlighting for Serilog message templates and Serilog.Expressions",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "publisher": "mtlog",
   "repository": {
     "type": "git",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -14,7 +14,6 @@ import { SerilogBraceMatchProvider } from './providers/braceMatchProvider';
 export function activate(context: vscode.ExtensionContext) {
     // Create output channel for logging
     const outputChannel = vscode.window.createOutputChannel('Serilog Syntax');
-    outputChannel.show();
 
     const themeManager = new ThemeManager();
     const currentTheme = themeManager.getCurrentTheme();
@@ -23,13 +22,8 @@ export function activate(context: vscode.ExtensionContext) {
     const extension = vscode.extensions.getExtension('mtlog.serilog-syntax-vscode');
     const version = extension?.packageJSON?.version || 'unknown';
 
-    outputChannel.appendLine('=================================');
-    outputChannel.appendLine(`Serilog Syntax Highlighting v${version}`);
-    outputChannel.appendLine('=================================');
-    outputChannel.appendLine(`Extension activated successfully`);
-    outputChannel.appendLine(`Theme: ${currentTheme === 'light' ? 'Light' : 'Dark'} mode`);
-    outputChannel.appendLine(`Repository: https://github.com/willibrandon/serilog-syntax-vscode`);
-    outputChannel.appendLine('');
+    // Log activation silently (users can view in Output panel if needed)
+    outputChannel.appendLine(`Serilog Syntax Highlighting v${version} activated (${currentTheme === 'light' ? 'Light' : 'Dark'} mode)`);
 
     const decorationManager = new DecorationManager(themeManager, outputChannel);
     const stringParser = new StringLiteralParser();


### PR DESCRIPTION
Fixes #1

  ## Changes
  - Remove `outputChannel.show()` call that interrupted user workflow on startup
  - Simplify activation logging to single concise line
  - Add proper problem matcher for watch task to eliminate VS Code warnings
  - Bump version to 0.2.2

  ## Testing
  - All 111 tests pass
  - Verified extension activates silently without forcing Output panel focus